### PR TITLE
Adding an overload that enables you to hold events by base type

### DIFF
--- a/Esp.Net/HeldEvents/IEventHoldingStrategy.cs
+++ b/Esp.Net/HeldEvents/IEventHoldingStrategy.cs
@@ -8,5 +8,10 @@ namespace Esp.Net.HeldEvents
         bool ShouldHold(TModel model, TEvent @event, IEventContext context);
         IEventDescription GetEventDescription(TModel model, TEvent @event);
     }
+
+    public interface IEventHoldingStrategy<in TModel, in TEvent, in TBaseEvent> : IEventHoldingStrategy<TModel, TEvent>
+        where TEvent : IIdentifiableEvent, TBaseEvent
+    {
+    }
 }
 #endif


### PR DESCRIPTION
This changes allows you to observe events from the router using a held event strategy targeting a base event type. 

Bit about why you need to hold events:
You may have an `EventProcessor` that needs to observe an events and if the event comes in you need to intercept the particular event, cancel it, model that an event is held then wait for further input (i.e. from a user) as to weather the event can be released. Typically this is done when the incoming event will blow away a load of state and you need to get confirmation, quite a common scenario.

You can now use a strategy that works with a `GetEventObservable` extension method to cancel the event and model that it's held. Other code looks at the model and raises a `HeldEventActionEvent` event which the below ext method will receive (it internally subscribe to this) then it release the held event.
```
_router.GetEventObservable(new HoldEventsBasedOnModelStrategy<FooEvent>()).Observe((m, e, c) =>
{
    // once released this is hit
});
``` 

The above is handy however if your `EventProcessor` needs to listen to 10 events and doesn't really care what each does, only that it needs to be held. In this case there is another overload `GetEventObservable` that takes an `IEventHoldingStrategy` that takes a base event. This allows for you to concat all the held events streams into a single observer:

```
var stream1 = EventObservable.Concat(
    _router.GetEventObservable(new HoldBaseEventsBasedOnModelStrategy<FooEvent, BaseEvent>()),
    _router.GetEventObservable(new HoldBaseEventsBasedOnModelStrategy<BarEvent, BaseEvent>())
);
stream1.Observe((model, baseEvent, context) =>
{
    // gets the base event when released
});
```