### PR TITLE
#34 done

### DIFF
--- a/src/Esp.Net.Tests/RouterTests.cs
+++ b/src/Esp.Net.Tests/RouterTests.cs
@@ -806,7 +806,7 @@ namespace Esp.Net
                 }
             }
         }
-
+        
         public class ModelRouter : RouterTests
         {
             private IRouter<TestModel> _modelRouter;
@@ -843,11 +843,44 @@ namespace Esp.Net
                 _model1EventProcessor.Event1Details.NormalStage.ReceivedEvents.Count.ShouldBe(1);
                 _model2EventProcessor.Event1Details.NormalStage.ReceivedEvents.Count.ShouldBe(1);
             }
+        }
+
+        public class ModelSubRouter : RouterTests
+        {
+            private IRouter<SubTestModel> _modelRouter;
+
+            [SetUp]
+            public override void SetUp()
+            {
+                base.SetUp();
+                _modelRouter = _router.CreateModelRouter<TestModel, SubTestModel>(_model1.Id, m => m.SubTestModel);
+            }
 
             [Test]
-            public void CanExeuteProxiedEvent()
+            public void CanPublishAndObserveProxiedEvent()
             {
-                Assert.Inconclusive();
+                List<Tuple<SubTestModel, Event1>> receivedSubModels = new List<Tuple<SubTestModel, Event1>>();
+                _modelRouter.GetEventObservable<Event1>().Observe((m, e, c) => receivedSubModels.Add(Tuple.Create(m, e)));
+                _modelRouter.PublishEvent(new Event1());
+                receivedSubModels.Count.ShouldBe(1);
+                receivedSubModels[0].Item1.ShouldBe(_model1.SubTestModel);
+            }
+
+            [Test]
+            public void CanObserveProxiedModel()
+            {
+                var receivedModelCount = 0;
+                _modelRouter.GetModelObservable().Observe(m => receivedModelCount++);
+                _modelRouter.PublishEvent(new Event1());
+                receivedModelCount.ShouldBe(1);
+            }
+
+            [Test]
+            public void CanBroadcastProxiedEvent()
+            {
+                _modelRouter.BroadcastEvent(new Event1());
+                _model1EventProcessor.Event1Details.NormalStage.ReceivedEvents.Count.ShouldBe(1);
+                _model2EventProcessor.Event1Details.NormalStage.ReceivedEvents.Count.ShouldBe(1);
             }
         }
 
@@ -1064,9 +1097,16 @@ namespace Esp.Net
             public TestModel()
             {
                 Id = Guid.NewGuid();
+                SubTestModel = new SubTestModel();
             }
             public Guid Id { get; private set; }
             public bool ControllerShouldRemove { get; set; }
+            public SubTestModel SubTestModel { get; private set; }
+        }
+
+        public class SubTestModel
+        {
+
         }
 
         public class TestModel3

--- a/src/Esp.Net/Esp.Net.csproj
+++ b/src/Esp.Net/Esp.Net.csproj
@@ -70,6 +70,7 @@
     <Compile Include="ModelRouter\IModelSubject.cs" />
     <Compile Include="ModelRouter\IRouter.cs" />
     <Compile Include="ModelRouter\ModelRouter.cs" />
+    <Compile Include="ModelRouter\SubModelRouter.cs" />
     <Compile Include="ObservationStage.cs" />
     <Compile Include="ObserveBaseEventAttribute.cs" />
     <Compile Include="ObserveEventAttribute.cs" />

--- a/src/Esp.Net/IRouter.cs
+++ b/src/Esp.Net/IRouter.cs
@@ -27,5 +27,6 @@ namespace Esp.Net
         void RegisterModel<TModel>(object modelId, TModel model, IPreEventProcessor<TModel> preEventProcessor, IPostEventProcessor<TModel> postEventProcessor);
         void RemoveModel(object modelId);
         IRouter<TModel> CreateModelRouter<TModel>(object modelId);
+        IRouter<TSubModel> CreateModelRouter<TModel, TSubModel>(object modelId, Func<TModel, TSubModel> subModelSelector);
     }
 }

--- a/src/Esp.Net/ModelRouter/SubModelRouter.cs
+++ b/src/Esp.Net/ModelRouter/SubModelRouter.cs
@@ -19,35 +19,37 @@ using Esp.Net.Reactive;
 
 namespace Esp.Net.ModelRouter
 {
-    internal class ModelRouter<TModel> : IRouter<TModel>
+    internal class SubModelRouter<TModel, TSubModel> : IRouter<TSubModel>
     {
+        private readonly Func<TModel, TSubModel> _selector;
         private readonly object _modelIid;
         private readonly IRouter _underlying;
 
-        public ModelRouter(object modelIid, IRouter underlying)
+        public SubModelRouter(object modelIid, IRouter underlying, Func<TModel, TSubModel> selector)
         {
             _modelIid = modelIid;
             _underlying = underlying;
+            _selector = selector;
         }
 
-        public IModelObservable<TModel> GetModelObservable()
+        public IModelObservable<TSubModel> GetModelObservable()
         {
-            return _underlying.GetModelObservable<TModel>(_modelIid);
+            return _underlying.GetModelObservable<TModel>(_modelIid).Select(_selector);
         }
 
-        public IEventObservable<TModel, TEvent, IEventContext> GetEventObservable<TEvent>(ObservationStage observationStage = ObservationStage.Normal)
+        public IEventObservable<TSubModel, TEvent, IEventContext> GetEventObservable<TEvent>(ObservationStage observationStage = ObservationStage.Normal)
         {
-            return _underlying.GetEventObservable<TModel, TEvent>(_modelIid, observationStage);
+            return _underlying.GetEventObservable<TModel, TEvent>(_modelIid, observationStage).Select(_selector);
         }
 
-        public IEventObservable<TModel, TBaseEvent, IEventContext> GetEventObservable<TSubEventType, TBaseEvent>(ObservationStage observationStage = ObservationStage.Normal) where TSubEventType : TBaseEvent
+        public IEventObservable<TSubModel, TBaseEvent, IEventContext> GetEventObservable<TSubEventType, TBaseEvent>(ObservationStage observationStage = ObservationStage.Normal) where TSubEventType : TBaseEvent
         {
-            return _underlying.GetEventObservable<TModel, TSubEventType, TBaseEvent>(_modelIid, observationStage);
+            return _underlying.GetEventObservable<TModel, TSubEventType, TBaseEvent>(_modelIid, observationStage).Select(_selector);
         }
 
-        public IEventObservable<TModel, TBaseEvent, IEventContext> GetEventObservable<TBaseEvent>(Type eventType, ObservationStage observationStage = ObservationStage.Normal)
+        public IEventObservable<TSubModel, TBaseEvent, IEventContext> GetEventObservable<TBaseEvent>(Type eventType, ObservationStage observationStage = ObservationStage.Normal)
         {
-            return _underlying.GetEventObservable<TModel, TBaseEvent>(_modelIid, eventType, observationStage);
+            return _underlying.GetEventObservable<TModel, TBaseEvent>(_modelIid, eventType, observationStage).Select(_selector);
         }
 
         public void PublishEvent<TEvent>(TEvent @event)

--- a/src/Esp.Net/Reactive/EventObservable.cs
+++ b/src/Esp.Net/Reactive/EventObservable.cs
@@ -111,6 +111,19 @@ namespace Esp.Net.Reactive
                 }
             );
         }
+
+        public static IEventObservable<TSubModel, TEvent, TContext> Select<TModel, TSubModel, TEvent, TContext>(this IEventObservable<TModel, TEvent, TContext> source, Func<TModel, TSubModel> subModelSelector)
+        {
+            return Create<TSubModel, TEvent, TContext>(
+                o =>
+                {
+                    return source.Observe(
+                        (m, e, c) => o.OnNext(subModelSelector(m), e, c),
+                        o.OnCompleted
+                    );
+                }
+            );
+        }
     }
 
     internal class EventObservable<TModel, TEvent, TContext> : IEventObservable<TModel, TEvent, TContext>

--- a/src/Esp.Net/Router.cs
+++ b/src/Esp.Net/Router.cs
@@ -176,6 +176,12 @@ namespace Esp.Net
             return new ModelRouter<TModel>(modelId, this);
         }
 
+        public IRouter<TSubModel> CreateModelRouter<TModel, TSubModel>(object modelId, Func<TModel, TSubModel> subModelSelector)
+        { 
+            _routerGuard.EnsureValid();
+            return new SubModelRouter<TModel, TSubModel>(modelId, this, subModelSelector);
+        }
+
         private void PurgeEventQueues()
         {
             if (_state.CurrentStatus == Status.Idle)


### PR DESCRIPTION
Satisfies #34. 
Adding support to create a scoped `IRouter<TSubModel>` that only targets a subset of another model. This promotes event processor reuseability as you don't have to take `IRouter<T>` where `T` is the entire model.

It also allows you to limit access to parts of the model from an event processor (as it's scope is restricted).

```
var router = new Router(threadGuard);
FooModel model = new FooModel();
router.RegisterModel(model.Id, model);
IRouter<Bar> barRouter = router.CreateModelRouter<FooModel, Bar>(id, fooModel => fooModel.Bar);
```